### PR TITLE
Add support for embedless urls (<url>)

### DIFF
--- a/util/parseInput.js
+++ b/util/parseInput.js
@@ -39,6 +39,8 @@ function fromAny({ first, last, attachments = new Collection() }) {
 		return fromEmojiAndName(first, last);
 	} else if (regexes.url.test(first) && regexes.wordsOnly.test(last)) {
 		return fromUrlAndName(first, last);
+	} else if (regexes.embedlessUrl.test(first) && regexes.wordsOnly.test(last)) {
+		return fromUrlAndName(first.slice(1, -1), last);
 	} else if (!regexes.wordsOnly.test(first)) {
 		throw new RangeError('Only alphanumeric characters are allowed!');
 	} else if (regexes.emoji.test(last)) {

--- a/util/parseInput.js
+++ b/util/parseInput.js
@@ -45,6 +45,8 @@ function fromAny({ first, last, attachments = new Collection() }) {
 		return fromNameAndEmoji(first, last);
 	} else if (!last && attachments.size) {
 		return fromNameAndAttachment(first, attachments.first());
+	} else if (regexes.embedlessUrl.test(last)) {
+		last = last.slice(1, -1);
 	} else if (!regexes.url.test(last)) {
 		throw new Error('That doesn\'t seem like a valid image URL.');
 	}

--- a/util/regexes.js
+++ b/util/regexes.js
@@ -1,6 +1,7 @@
 module.exports.wordsOnly = /^\w+$/;
 module.exports.emoji = /<(a)?:(\w+):(\d+)>/;
 module.exports.url = /(https?:\/\/)?(www.)?[^\s<>#%{}|\\^~\\[\]]+\.(png|jpe?g|webp|gif)(\?v=\d*)?$/;
+module.exports.embedlessUrl = /<(https?:\/\/)?(www.)?[^\s<>#%{}|\\^~\\[\]]+\.(png|jpe?g|webp|gif)(\?v=\d*)?>$/;
 module.exports.png = /\.png(\?v=\d*)?$/;
 module.exports.gif = /\.gif(\?v=\d*)?$/;
 module.exports.blob = /^a?b(lo|ol)b[a-z]+$/;


### PR DESCRIPTION
This PR adds support for embedless (I have no clue whether those have an official name) urls as emoji source.
Those are urls like: `<https://example.com/emoji.png>` instead of `https://example.com/emoji.png`.
